### PR TITLE
feat: Add raindrop and local bookmark on action button click

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
   "version": "1.11.0",
   "description": "Automatically syncs your Raindrop.io bookmarks to Chrome daily—no manual export required.",
   "permissions": [
+    "tabs",
     "bookmarks",
     "storage",
     "notifications",

--- a/src/components/raindrop.js
+++ b/src/components/raindrop.js
@@ -239,3 +239,44 @@ function getCurrentLevel(line) {
   const leadingSpaces = line.match(/^(\s*)/);
   return leadingSpaces ? Math.floor(leadingSpaces[1].length / 2) : 0;
 }
+
+/**
+ * Adds a new raindrop to the user's collection.
+ *
+ * @async
+ * @param {string} token - The API token for the Raindrop API.
+ * @param {string} url - The URL of the page to add.
+ * @param {string} title - The title of the page.
+ * @returns {Promise<Object>} The newly created raindrop.
+ */
+export async function addRaindrop(token, url, title) {
+  try {
+    const response = await fetch('https://api.raindrop.io/rest/v1/raindrop', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        link: url,
+        title: title,
+      }),
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.result) {
+        return data.item;
+      } else {
+        throw new Error(data.errorMessage || 'Failed to add raindrop');
+      }
+    } else {
+      throw new Error(
+        `Failed to add raindrop: ${response.status} ${response.statusText}`,
+      );
+    }
+  } catch (error) {
+    console.error('Error adding raindrop:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
This commit introduces the following features:

- When you click the action button, the extension now captures the title and URL of the active tab.
- It then calls the Raindrop.io API to create a new raindrop.
- A new local bookmark is also created under a "Raindrop" folder.
- The action button badge provides feedback to you: "⏳" for processing, "✅" for success, and "😵‍💫" for failure.
- If the Raindrop.io API token is not configured, clicking the action button will open the options page.