### PR TITLE
feat: Add "Open options page" to action button behaviors

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -547,6 +547,9 @@ chrome.action.onClicked.addListener(async () => {
     case 'sync':
       startBackup();
       break;
+    case 'open_options':
+      chrome.runtime.openOptionsPage();
+      break;
     case 'none':
       break;
     default:

--- a/src/options.html
+++ b/src/options.html
@@ -75,6 +75,7 @@
               <select id="actionButtonBehavior" class="preference-select">
                 <option value="save">💾 Save tab(s) to Raindrop</option>
                 <option value="sync">🔄 Trigger manual sync</option>
+                <option value="open_options">⚙️ Open options page</option>
                 <option value="none">⚪ Do nothing</option>
               </select>
             </div>


### PR DESCRIPTION
Adds a new choice to the "Action Button Behavior" dropdown on the options page.

The new option, "Open options page", allows you to configure the extension's toolbar button to open the options page directly.

Changes:
- Modified `src/options.html` to include the new dropdown option.
- Updated `src/background.js` to handle the new `open_options` behavior in the `chrome.action.onClicked` listener.