### PR TITLE
feat: preserve Raindrop collection structure in bookmark sync

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+README.md export-ignore
+LICENSE export-ignore
+package.json export-ignore
+package-lock.json export-ignore
+/.github export-ignore
+/docs export-ignore
+/icons export-ignore
+/node_modules export-ignore

--- a/docs/chrome extension/chrome.bookmarks  -  API  -  Chrome for Developers_20250801-2159.md
+++ b/docs/chrome extension/chrome.bookmarks  -  API  -  Chrome for Developers_20250801-2159.md
@@ -1,0 +1,1040 @@
+# chrome.bookmarks  |  API  |  Chrome for Developers
+
+**URL:** https://developer.chrome.com/docs/extensions/reference/api/bookmarks
+
+**Extracted:** 2025-08-01T13:59:50.344Z
+
+---
+
+<content>
+[Skip to main content](#main-content)
+
+- [Chrome Extensions](https://developer.chrome.com/docs/extensions)
+- [Reference](https://developer.chrome.com/docs/extensions/reference)
+- [API](https://developer.chrome.com/docs/extensions/reference/api)
+
+- On this page
+- [Description](#description)
+- [Permissions](#permissions)
+- [Concepts and usage](#concepts_and_usage)
+  - [Objects and properties](#objects_and_properties)
+  - [Examples](#overview-examples)
+- [Types](#type)
+  - [BookmarkTreeNode](#type-BookmarkTreeNode)
+  - [BookmarkTreeNodeUnmodifiable](#type-BookmarkTreeNodeUnmodifiable)
+  - [CreateDetails](#type-CreateDetails)
+  - [FolderType](#type-FolderType)
+- [Properties](#property)
+  - [MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE](#property-MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE)
+  - [MAX_WRITE_OPERATIONS_PER_HOUR](#property-MAX_WRITE_OPERATIONS_PER_HOUR)
+- [Methods](#method)
+  - [create()](#method-create)
+  - [get()](#method-get)
+  - [getChildren()](#method-getChildren)
+  - [getRecent()](#method-getRecent)
+  - [getSubTree()](#method-getSubTree)
+  - [getTree()](#method-getTree)
+  - [move()](#method-move)
+  - [remove()](#method-remove)
+  - [removeTree()](#method-removeTree)
+  - [search()](#method-search)
+  - [update()](#method-update)
+- [Events](#event)
+
+  - [onChanged](#event-onChanged)
+  - [onChildrenReordered](#event-onChildrenReordered)
+  - [onCreated](#event-onCreated)
+  - [onImportBegan](#event-onImportBegan)
+  - [onImportEnded](#event-onImportEnded)
+  - [onMoved](#event-onMoved)
+  - [onRemoved](#event-onRemoved)
+
+- [Home](https://developer.chrome.com/)
+- [Docs](https://developer.chrome.com/docs)
+- [Chrome Extensions](https://developer.chrome.com/docs/extensions)
+- [Reference](https://developer.chrome.com/docs/extensions/reference)
+- [API](https://developer.chrome.com/docs/extensions/reference/api)
+
+Was this helpful?
+
+# chrome.bookmarks
+
+bookmark_border Stay organized with collections Save and categorize content based on your preferences.
+
+- On this page
+- [Description](#description)
+- [Permissions](#permissions)
+- [Concepts and usage](#concepts_and_usage)
+  - [Objects and properties](#objects_and_properties)
+  - [Examples](#overview-examples)
+- [Types](#type)
+  - [BookmarkTreeNode](#type-BookmarkTreeNode)
+  - [BookmarkTreeNodeUnmodifiable](#type-BookmarkTreeNodeUnmodifiable)
+  - [CreateDetails](#type-CreateDetails)
+  - [FolderType](#type-FolderType)
+- [Properties](#property)
+  - [MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE](#property-MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE)
+  - [MAX_WRITE_OPERATIONS_PER_HOUR](#property-MAX_WRITE_OPERATIONS_PER_HOUR)
+- [Methods](#method)
+  - [create()](#method-create)
+  - [get()](#method-get)
+  - [getChildren()](#method-getChildren)
+  - [getRecent()](#method-getRecent)
+  - [getSubTree()](#method-getSubTree)
+  - [getTree()](#method-getTree)
+  - [move()](#method-move)
+  - [remove()](#method-remove)
+  - [removeTree()](#method-removeTree)
+  - [search()](#method-search)
+  - [update()](#method-update)
+- [Events](#event)
+  - [onChanged](#event-onChanged)
+  - [onChildrenReordered](#event-onChildrenReordered)
+  - [onCreated](#event-onCreated)
+  - [onImportBegan](#event-onImportBegan)
+  - [onImportEnded](#event-onImportEnded)
+  - [onMoved](#event-onMoved)
+  - [onRemoved](#event-onRemoved)
+
+## Description
+
+Use the `chrome.bookmarks` API to create, organize, and otherwise manipulate bookmarks. Also see [Override Pages](https://developer.chrome.com/docs/extensions/override), which you can use to create a custom Bookmark Manager page.
+
+Clicking the star adds a bookmark.
+
+## Permissions
+
+`bookmarks`
+
+You must declare the "bookmarks" permission in the [extension manifest](/docs/extensions/reference/manifest) to use the bookmarks API. For example:
+
+```
+{
+  "name": "My extension",
+  ...
+  "permissions": [
+    "bookmarks"
+  ],
+  ...
+}
+```
+
+## Concepts and usage
+
+### Objects and properties
+
+Bookmarks are organized in a tree, where each node in the tree is either a bookmark or a folder (sometimes called a _group_). Each node in the tree is represented by a [bookmarks.BookmarkTreeNode](#type-BookmarkTreeNode) object.
+
+`BookmarkTreeNode` properties are used throughout the `chrome.bookmarks` API. For example, when you call [bookmarks.create](#method-create), you pass in the new node's parent (`parentId`), and, optionally, the node's `index`, `title`, and `url` properties. See [bookmarks.BookmarkTreeNode](#type-BookmarkTreeNode) for information about the properties a node can have.
+
+### Examples
+
+The following code creates a folder with the title "Extension bookmarks". The first argument to `create()` specifies properties for the new folder. The second argument defines a function to be executed after the folder is created.
+
+```
+chrome.bookmarks.create(
+  {'parentId': bookmarkBar.id, 'title': 'Extension bookmarks'},
+  function(newFolder) {
+    console.log("added folder: " + newFolder.title);
+  },
+);
+```
+
+The next snippet creates a bookmark pointing to the developer documentation for extensions. Since nothing bad will happen if creating the bookmark fails, this code doesn't bother to define a callback function.
+
+```
+chrome.bookmarks.create({
+  'parentId': extensionsFolderId,
+  'title': 'Extensions doc',
+  'url': 'https://developer.chrome.com/docs/extensions',
+});
+```
+
+To try this API, install the [Bookmarks API example](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples/bookmarks) from the [chrome-extension-samples](https://github.com/GoogleChrome/chrome-extensions-samples/tree/main/api-samples) repository.
+
+## Types
+
+### BookmarkTreeNode
+
+A node (either a bookmark or a folder) in the bookmark tree. Child nodes are ordered within their parent folder.
+
+#### Properties
+
+- children
+
+  [BookmarkTreeNode](#type-BookmarkTreeNode)\[\] optional
+
+  An ordered list of children of this node.
+
+- dateAdded
+
+  number optional
+
+  When this node was created, in milliseconds since the epoch (`new Date(dateAdded)`).
+
+- dateGroupModified
+
+  number optional
+
+  When the contents of this folder last changed, in milliseconds since the epoch.
+
+- dateLastUsed
+
+  number optional
+
+  Chrome 114+
+
+  When this node was last opened, in milliseconds since the epoch. Not set for folders.
+
+- folderType
+
+  [FolderType](#type-FolderType) optional
+
+  Chrome 134+
+
+  If present, this is a folder that is added by the browser and that cannot be modified by the user or the extension. Child nodes may be modified, if this node does not have the `unmodifiable` property set. Omitted if the node can be modified by the user and the extension (default).
+
+  There may be zero, one or multiple nodes of each folder type. A folder may be added or removed by the browser, but not via the extensions API.
+
+- id
+
+  string
+
+  The unique identifier for the node. IDs are unique within the current profile, and they remain valid even after the browser is restarted.
+
+- index
+
+  number optional
+
+  The 0-based position of this node within its parent folder.
+
+- parentId
+
+  string optional
+
+  The `id` of the parent folder. Omitted for the root node.
+
+- syncing
+
+  boolean
+
+  Chrome 134+
+
+  Whether this node is synced with the user's remote account storage by the browser. This can be used to distinguish between account and local-only versions of the same [`FolderType`](#type-FolderType). The value of this property may change for an existing node, for example as a result of user action.
+
+  Note: this reflects whether the node is saved to the browser's built-in account provider. It is possible that a node could be synced via a third-party, even if this value is false.
+
+  For managed nodes (nodes where `unmodifiable` is set to `true`), this property will always be `false`.
+
+- title
+
+  string
+
+  The text displayed for the node.
+
+- unmodifiable
+
+  "managed"
+
+  optional
+
+  Indicates the reason why this node is unmodifiable. The `managed` value indicates that this node was configured by the system administrator or by the custodian of a supervised user. Omitted if the node can be modified by the user and the extension (default).
+
+- url
+
+  string optional
+
+  The URL navigated to when a user clicks the bookmark. Omitted for folders.
+
+### BookmarkTreeNodeUnmodifiable
+
+Chrome 44+
+
+Indicates the reason why this node is unmodifiable. The `managed` value indicates that this node was configured by the system administrator. Omitted if the node can be modified by the user and the extension (default).
+
+#### Value
+
+"managed"
+
+### CreateDetails
+
+Object passed to the create() function.
+
+#### Properties
+
+- index
+
+  number optional
+
+- parentId
+
+  string optional
+
+  Defaults to the Other Bookmarks folder.
+
+- title
+
+  string optional
+
+- url
+
+  string optional
+
+### FolderType
+
+Chrome 134+
+
+Indicates the type of folder.
+
+#### Enum
+
+"bookmarks-bar"
+
+The folder whose contents is displayed at the top of the browser window.
+
+"other"
+
+Bookmarks which are displayed in the full list of bookmarks on all platforms.
+
+"mobile"
+
+Bookmarks generally available on the user's mobile devices, but modifiable by extension or in the bookmarks manager.
+
+"managed"
+
+A top-level folder that may be present if the system administrator or the custodian of a supervised user has configured bookmarks.
+
+## Properties
+
+### MAX_SUSTAINED_WRITE_OPERATIONS_PER_MINUTE
+
+Deprecated
+
+Bookmark write operations are no longer limited by Chrome.
+
+#### Value
+
+1000000
+
+### MAX_WRITE_OPERATIONS_PER_HOUR
+
+Deprecated
+
+Bookmark write operations are no longer limited by Chrome.
+
+#### Value
+
+1000000
+
+## Methods
+
+### create()
+
+Promise
+
+chrome.bookmarks.create(
+
+bookmark: [CreateDetails](#type-CreateDetails),
+
+callback?: function,
+
+)
+
+Creates a bookmark or folder under the specified parentId. If url is NULL or missing, it will be a folder.
+
+#### Parameters
+
+- bookmark
+
+  [CreateDetails](#type-CreateDetails)
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (result: [BookmarkTreeNode](#type-BookmarkTreeNode)) => void
+
+  - result
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### get()
+
+Promise
+
+chrome.bookmarks.get(
+
+idOrIdList: string | \[string, ...string\[\]\],
+
+callback?: function,
+
+)
+
+Retrieves the specified BookmarkTreeNode(s).
+
+#### Parameters
+
+- idOrIdList
+
+  string | \[string, ...string\[\]\]
+
+  A single string-valued id, or an array of string-valued ids
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (results: [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]) => void
+
+  - results
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\[\]>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### getChildren()
+
+Promise
+
+chrome.bookmarks.getChildren(
+
+id: string,
+
+callback?: function,
+
+)
+
+Retrieves the children of the specified BookmarkTreeNode id.
+
+#### Parameters
+
+- id
+
+  string
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (results: [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]) => void
+
+  - results
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\[\]>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### getRecent()
+
+Promise
+
+chrome.bookmarks.getRecent(
+
+numberOfItems: number,
+
+callback?: function,
+
+)
+
+Retrieves the recently added bookmarks.
+
+#### Parameters
+
+- numberOfItems
+
+  number
+
+  The maximum number of items to return.
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (results: [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]) => void
+
+  - results
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\[\]>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### getSubTree()
+
+Promise
+
+chrome.bookmarks.getSubTree(
+
+id: string,
+
+callback?: function,
+
+)
+
+Retrieves part of the Bookmarks hierarchy, starting at the specified node.
+
+#### Parameters
+
+- id
+
+  string
+
+  The ID of the root of the subtree to retrieve.
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (results: [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]) => void
+
+  - results
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\[\]>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### getTree()
+
+Promise
+
+chrome.bookmarks.getTree(
+
+callback?: function,
+
+)
+
+Retrieves the entire Bookmarks hierarchy.
+
+#### Parameters
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (results: [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]) => void
+
+  - results
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\[\]>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### move()
+
+Promise
+
+chrome.bookmarks.move(
+
+id: string,
+
+destination: object,
+
+callback?: function,
+
+)
+
+Moves the specified BookmarkTreeNode to the provided location.
+
+#### Parameters
+
+- id
+
+  string
+
+- destination
+
+  object
+
+  - index
+
+    number optional
+
+  - parentId
+
+    string optional
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (result: [BookmarkTreeNode](#type-BookmarkTreeNode)) => void
+
+  - result
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### remove()
+
+Promise
+
+chrome.bookmarks.remove(
+
+id: string,
+
+callback?: function,
+
+)
+
+Removes a bookmark or an empty bookmark folder.
+
+#### Parameters
+
+- id
+
+  string
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  () => void
+
+#### Returns
+
+- Promise<void>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### removeTree()
+
+Promise
+
+chrome.bookmarks.removeTree(
+
+id: string,
+
+callback?: function,
+
+)
+
+Recursively removes a bookmark folder.
+
+#### Parameters
+
+- id
+
+  string
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  () => void
+
+#### Returns
+
+- Promise<void>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### search()
+
+Promise
+
+chrome.bookmarks.search(
+
+query: string | object,
+
+callback?: function,
+
+)
+
+Searches for BookmarkTreeNodes matching the given query. Queries specified with an object produce BookmarkTreeNodes matching all specified properties.
+
+#### Parameters
+
+- query
+
+  string | object
+
+  Either a string of words and quoted phrases that are matched against bookmark URLs and titles, or an object. If an object, the properties `query`, `url`, and `title` may be specified and bookmarks matching all specified properties will be produced.
+
+  - query
+
+    string optional
+
+    A string of words and quoted phrases that are matched against bookmark URLs and titles.
+
+  - title
+
+    string optional
+
+    The title of the bookmark; matches verbatim.
+
+  - url
+
+    string optional
+
+    The URL of the bookmark; matches verbatim. Note that folders have no URL.
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (results: [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]) => void
+
+  - results
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)\[\]
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\[\]>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+### update()
+
+Promise
+
+chrome.bookmarks.update(
+
+id: string,
+
+changes: object,
+
+callback?: function,
+
+)
+
+Updates the properties of a bookmark or folder. Specify only the properties that you want to change; unspecified properties will be left unchanged. **Note:** Currently, only 'title' and 'url' are supported.
+
+#### Parameters
+
+- id
+
+  string
+
+- changes
+
+  object
+
+  - title
+
+    string optional
+
+  - url
+
+    string optional
+
+- callback
+
+  function optional
+
+  The `callback` parameter looks like:
+
+  (result: [BookmarkTreeNode](#type-BookmarkTreeNode)) => void
+
+  - result
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)
+
+#### Returns
+
+- Promise<[BookmarkTreeNode](#type-BookmarkTreeNode)\>
+
+  Chrome 90+
+
+  Promises are supported in Manifest V3 and later, but callbacks are provided for backward compatibility. You cannot use both on the same function call. The promise resolves with the same type that is passed to the callback.
+
+## Events
+
+### onChanged
+
+chrome.bookmarks.onChanged.addListener(
+
+callback: function,
+
+)
+
+Fired when a bookmark or folder changes. **Note:** Currently, only title and url changes trigger this.
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  (id: string, changeInfo: object) => void
+
+  - id
+
+    string
+
+  - changeInfo
+
+    object
+
+    - title
+
+      string
+
+    - url
+
+      string optional
+
+### onChildrenReordered
+
+chrome.bookmarks.onChildrenReordered.addListener(
+
+callback: function,
+
+)
+
+Fired when the children of a folder have changed their order due to the order being sorted in the UI. This is not called as a result of a move().
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  (id: string, reorderInfo: object) => void
+
+  - id
+
+    string
+
+  - reorderInfo
+
+    object
+
+    - childIds
+
+      string\[\]
+
+### onCreated
+
+chrome.bookmarks.onCreated.addListener(
+
+callback: function,
+
+)
+
+Fired when a bookmark or folder is created.
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  (id: string, bookmark: [BookmarkTreeNode](#type-BookmarkTreeNode)) => void
+
+  - id
+
+    string
+
+  - bookmark
+
+    [BookmarkTreeNode](#type-BookmarkTreeNode)
+
+### onImportBegan
+
+chrome.bookmarks.onImportBegan.addListener(
+
+callback: function,
+
+)
+
+Fired when a bookmark import session is begun. Expensive observers should ignore onCreated updates until onImportEnded is fired. Observers should still handle other notifications immediately.
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  () => void
+
+### onImportEnded
+
+chrome.bookmarks.onImportEnded.addListener(
+
+callback: function,
+
+)
+
+Fired when a bookmark import session is ended.
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  () => void
+
+### onMoved
+
+chrome.bookmarks.onMoved.addListener(
+
+callback: function,
+
+)
+
+Fired when a bookmark or folder is moved to a different parent folder.
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  (id: string, moveInfo: object) => void
+
+  - id
+
+    string
+
+  - moveInfo
+
+    object
+
+    - index
+
+      number
+
+    - oldIndex
+
+      number
+
+    - oldParentId
+
+      string
+
+    - parentId
+
+      string
+
+### onRemoved
+
+chrome.bookmarks.onRemoved.addListener(
+
+callback: function,
+
+)
+
+Fired when a bookmark or folder is removed. When a folder is removed recursively, a single notification is fired for the folder, and none for its contents.
+
+#### Parameters
+
+- callback
+
+  function
+
+  The `callback` parameter looks like:
+
+  (id: string, removeInfo: object) => void
+
+  - id
+
+    string
+
+  - removeInfo
+
+    object
+
+    - index
+
+      number
+
+    - node
+
+      [BookmarkTreeNode](#type-BookmarkTreeNode)
+
+      Chrome 48+
+
+    - parentId
+
+      string
+
+Was this helpful?
+
+Except as otherwise noted, the content of this page is licensed under the [Creative Commons Attribution 4.0 License](https://creativecommons.org/licenses/by/4.0/), and code samples are licensed under the [Apache 2.0 License](https://www.apache.org/licenses/LICENSE-2.0). For details, see the [Google Developers Site Policies](https://developers.google.com/site-policies). Java is a registered trademark of Oracle and/or its affiliates.
+
+Last updated 2025-02-28 UTC.
+</content>

--- a/docs/raindrop api/Collections - API Documentation_20250801-2230.md
+++ b/docs/raindrop api/Collections - API Documentation_20250801-2230.md
@@ -1,0 +1,173 @@
+# Collections | API Documentation
+
+**URL:** https://developer.raindrop.io/v1/collections
+
+**Extracted:** 2025-08-01T14:30:14.309Z
+
+---
+
+<content>
+### 
+
+[](#fields)
+
+Fields
+
+Field
+
+Type
+
+Description
+
+\_id
+
+`Integer`
+
+The id of the collection.
+
+access
+
+`Object`
+
+access.level
+
+`Integer`
+
+1.  read only access (equal to `public=true`)
+    
+2.  collaborator with read only access
+    
+3.  collaborator with write only access
+    
+4.  owner
+    
+
+access.draggable
+
+`Boolean`
+
+Does it possible to change parent of this collection?
+
+collaborators
+
+`Object`
+
+When this object is present, means that collections is shared. Content of this object is private and not very useful. All sharing API methods [described here](/v1/collections/sharing)
+
+color
+
+`String`
+
+Primary color of collection cover as `HEX`
+
+count
+
+`Integer`
+
+Count of raindrops in collection
+
+cover
+
+`Array<String>`
+
+Collection cover URL. This array always have one item due to legacy reasons
+
+created
+
+`String`
+
+When collection is created
+
+expanded
+
+`Boolean`
+
+Whether the collection’s sub-collections are expanded
+
+lastUpdate
+
+`String`
+
+When collection is updated
+
+parent
+
+`Object`
+
+parent.$id
+
+`Integer`
+
+The id of the parent collection. Not specified for root collections
+
+public
+
+`Boolean`
+
+Collection and raindrops that it contains will be accessible without authentication by public link
+
+sort
+
+`Integer`
+
+The order of collection (descending). Defines the position of the collection among all the collections with the same `parent.$id`
+
+title
+
+`String`
+
+Name of the collection
+
+user
+
+`Object`
+
+user.$id
+
+`Integer`
+
+Owner ID
+
+view
+
+`String`
+
+View style of collection, can be:
+
+-   `list` (default)
+    
+-   `simple`
+    
+-   `grid`
+    
+-   `masonry` Pinterest like grid
+    
+
+Our API response could contain **other fields**, not described above. It's **unsafe to use** them in your integration! They could be removed or renamed at any time.
+
+### 
+
+[](#system-collections)
+
+System collections
+
+Every user have several system non-removable collections. They are not contained in any API responses.
+
+\_id
+
+Description
+
+**\-1**
+
+"**Unsorted**" collection
+
+**\-99**
+
+"**Trash**" collection
+
+[PreviousMake authorized calls](/v1/authentication/calls)[NextCollection methods](/v1/collections/methods)
+
+Last updated 5 years ago
+
+Was this helpful?
+</content>

--- a/docs/raindrop api/Raindrops - API Documentation_20250801-2230.md
+++ b/docs/raindrop api/Raindrops - API Documentation_20250801-2230.md
@@ -1,0 +1,263 @@
+# Raindrops | API Documentation
+
+**URL:** https://developer.raindrop.io/v1/raindrops
+
+**Extracted:** 2025-08-01T14:30:10.350Z
+
+---
+
+<content>
+### 
+
+[](#main-fields)
+
+Main fields
+
+Field
+
+Type
+
+Description
+
+\_id
+
+`Integer`
+
+Unique identifier
+
+collection
+
+`Object`
+
+​
+
+collection.$id
+
+`Integer`
+
+Collection that the raindrop resides in
+
+cover
+
+`String`
+
+Raindrop cover URL
+
+created
+
+`String`
+
+Creation date
+
+domain
+
+`String`
+
+Hostname of a link. Files always have `raindrop.io` hostname
+
+excerpt
+
+`String`
+
+Description; max length: 10000
+
+note
+
+`String`
+
+Note; max length: 10000
+
+lastUpdate
+
+`String`
+
+Update date
+
+link
+
+`String`
+
+URL
+
+media
+
+`Array<Object>`
+
+​Covers list in format: `[ {"link":"url"} ]`
+
+tags
+
+`Array<String>`
+
+Tags list
+
+title
+
+`String`
+
+Title; max length: 1000
+
+type
+
+`String`
+
+`link` `article` `image` `video` `document` or `audio`
+
+user
+
+`Object`
+
+​
+
+user.$id
+
+`Integer`
+
+Raindrop owner
+
+### 
+
+[](#other-fields)
+
+Other fields
+
+Field
+
+Type
+
+Description
+
+broken
+
+`Boolean`
+
+Marked as broken (original `link` is not reachable anymore)
+
+cache
+
+`Object`
+
+Permanent copy (cached version) details
+
+cache.status
+
+`String`
+
+`ready` `retry` `failed` `invalid-origin` `invalid-timeout` or `invalid-size`
+
+cache.size
+
+`Integer`
+
+Full size in bytes
+
+cache.created
+
+`String`
+
+Date when copy is successfully made
+
+creatorRef
+
+`Object`
+
+Sometime raindrop may belong to other user, not to the one who created it. For example when this raindrop is created in shared collection by other user. This object contains info about original author.
+
+creatorRef.\_id
+
+`Integer`
+
+Original author (user ID) of a raindrop
+
+creatorRef.fullName
+
+`String`
+
+Original author name of a raindrop
+
+file
+
+`Object`
+
+This raindrop uploaded from desktop
+
+[Supported file formats](https://help.raindrop.io/article/48-uploading-files)
+
+file.name
+
+`String`
+
+File name
+
+file.size
+
+`Integer`
+
+File size in bytes
+
+file.type
+
+`String`
+
+Mime type
+
+important
+
+`Boolean`
+
+Marked as "favorite"
+
+highlights
+
+`Array`
+
+highlights\[\].\_id
+
+`String`
+
+Unique id of highlight
+
+highlights\[\].text
+
+`String`
+
+Text of highlight (required)
+
+highlights\[\].color
+
+`String`
+
+Color of highlight. Default `yellow` Can be `blue`, `brown`, `cyan`, `gray`, `green`, `indigo`, `orange`, `pink`, `purple`, `red`, `teal`, `yellow`
+
+highlights\[\].note
+
+`String`
+
+Optional note for highlight
+
+highlights\[\].created
+
+`String`
+
+Creation date of highlight
+
+reminder
+
+`Object`
+
+Specify this object to attach reminder
+
+reminder.data
+
+`Date`
+
+YYYY-MM-DDTHH:mm:ss.sssZ
+
+Our API response could contain **other fields**, not described above. It's **unsafe to use** them in your integration! They could be removed or renamed at any time.
+
+[PreviousCovers/icons](/v1/collections/covers-icons)[NextSingle raindrop](/v1/raindrops/single)
+
+Last updated 1 year ago
+
+Was this helpful?
+</content>

--- a/docs/raindrop api/User - API Documentation_20250801-2221.md
+++ b/docs/raindrop api/User - API Documentation_20250801-2221.md
@@ -1,0 +1,313 @@
+# User | API Documentation
+
+**URL:** https://developer.raindrop.io/v1/user#single-group-detail
+
+**Extracted:** 2025-08-01T14:21:46.140Z
+
+---
+
+<selectedText>
+Group
+</selectedText>
+
+<content>
+### 
+
+[](#main-fields)
+
+Main fields
+
+Field
+
+Publicly visible
+
+Type
+
+Description
+
+\_id
+
+**Yes**
+
+`Integer`
+
+Unique user ID
+
+config
+
+No
+
+`Object`
+
+More details in "Config fields"
+
+email
+
+No
+
+`String`
+
+Only visible for you
+
+email\_MD5
+
+**Yes**
+
+`String`
+
+MD5 hash of email. Useful for using with Gravatar for example
+
+files.used
+
+No
+
+`Integer`
+
+How much space used for files this month
+
+files.size
+
+No
+
+`Integer`
+
+Total space for file uploads
+
+files.lastCheckPoint
+
+No
+
+`String`
+
+When space for file uploads is reseted last time
+
+fullName
+
+**Yes**
+
+`String`
+
+Full name, max 1000 chars
+
+groups
+
+No
+
+`Array<Object>`
+
+More details below in "Groups"
+
+password
+
+No
+
+`Boolean`
+
+Does user have a password
+
+pro
+
+**Yes**
+
+`Boolean`
+
+PRO subscription
+
+proExpire
+
+No
+
+`String`
+
+When PRO subscription will expire
+
+registered
+
+No
+
+`String`
+
+Registration date
+
+### 
+
+[](#config-fields)
+
+Config fields
+
+Field
+
+Publicly visible
+
+Type
+
+Description
+
+config.broken\_level
+
+No
+
+`String`
+
+Broken links finder configuration, possible values:
+
+`basic` `default` `strict` or `off`
+
+config.font\_color
+
+No
+
+`String`
+
+Bookmark preview style: `sunset` `night` or empty
+
+config.font\_size
+
+No
+
+`Integer`
+
+Bookmark preview font size: from 0 to 9
+
+config.lang
+
+No
+
+`String`
+
+UI language in 2 char code
+
+config.last\_collection
+
+No
+
+`Integer`
+
+Last viewed collection ID
+
+config.raindrops\_sort
+
+No
+
+`String`
+
+Default bookmark sort:
+
+`title` `-title` `-sort` `domain` `-domain` `+lastUpdate` or `-lastUpdate`
+
+config.raindrops\_view
+
+No
+
+`String`
+
+Default bookmark view:
+
+`grid` `list` `simple` or `masonry`
+
+### 
+
+[](#single-group-detail)
+
+Groups object fields
+
+Field
+
+Type
+
+Description
+
+title
+
+`String`
+
+Name of group
+
+hidden
+
+`Boolean`
+
+Does group is collapsed
+
+sort
+
+`Integer`
+
+Ascending order position
+
+collections
+
+`Array<Integer>`
+
+Collection ID's in order
+
+### 
+
+[](#other-fields)
+
+Other fields
+
+Field
+
+Publicly visible
+
+Type
+
+Description
+
+facebook.enabled
+
+No
+
+`Boolean`
+
+Does Facebook account is linked
+
+twitter.enabled
+
+No
+
+`Boolean`
+
+Does Twitter account is linked
+
+vkontakte.enabled
+
+No
+
+`Boolean`
+
+Does Vkontakte account is linked
+
+google.enabled
+
+No
+
+`Boolean`
+
+Does Google account is linked
+
+dropbox.enabled
+
+No
+
+`Boolean`
+
+Does Dropbox backup is enabled
+
+gdrive.enabled
+
+No
+
+`Boolean`
+
+Does Google Drive backup is enabled
+
+Our API response could contain **other fields**, not described above. It's **unsafe to use** them in your integration! They could be removed or renamed at any time.
+
+[PreviousHighlights](/v1/highlights)[NextAuthenticated user](/v1/user/authenticated)
+
+Last updated 1 year ago
+
+Was this helpful?
+</content>

--- a/src/background.js
+++ b/src/background.js
@@ -3,12 +3,21 @@ import { showNotification } from './components/notification.js';
 import {
   parseRaindropBackup,
   getLatestChange,
-  exportAllRaindrops,
   addRaindrops,
+  getRootCollections,
+  getChildCollections,
+  buildCollectionTree,
+  getUserData,
+  buildCollectionTreeWithGroups,
+  fetchRaindropsPaginated,
+  createBookmarkFromRaindrop,
+  processRaindropsPage,
 } from './components/raindrop.js';
 import {
   deleteExistingRaindropFolder,
   createBookmarksFromStructure,
+  deleteExistingRaindropSyncFolder,
+  createCollectionFolderStructure,
 } from './components/bookmarks.js';
 
 console.log('Raindrop Sync background service worker started');
@@ -100,6 +109,25 @@ function sendStatusUpdate(status, type, step) {
 // Check if sync is needed by comparing the latest change date with the last processed date
 async function checkIfSyncNeeded(token) {
   try {
+    // Check if local "Raindrop" bookmark folder exists
+    const searchResults = await chrome.bookmarks.search({
+      title: 'RaindropSync',
+    });
+    const raindropFolderExists = searchResults.some(
+      (bookmark) => !bookmark.url,
+    ); // folder has no URL
+
+    if (!raindropFolderExists) {
+      console.log('Local "Raindrop" bookmark folder not found - sync needed');
+      // Still get the latest change timestamp for proper tracking
+      const latestChangeTimestamp = await getLatestChange(token);
+      return {
+        syncNeeded: true,
+        latestChangeTimestamp: latestChangeTimestamp || Date.now(),
+        reason: 'missing_local_folder',
+      };
+    }
+
     // Get the timestamp of the latest change (updated, created, or deleted)
     const latestChangeTimestamp = await getLatestChange(token);
 
@@ -127,71 +155,11 @@ async function checkIfSyncNeeded(token) {
     return {
       syncNeeded,
       latestChangeTimestamp,
+      reason: syncNeeded ? 'new_changes' : 'up_to_date',
     };
   } catch (error) {
     console.error('Error checking if sync is needed:', error);
     throw error;
-  }
-}
-
-// Main function to sync Raindrop backup with browser bookmarks
-async function syncRaindropBookmarks(htmlContent) {
-  try {
-    sendStatusUpdate('Parsing backup content...', 'info', 'parsing');
-
-    // Parse the backup HTML
-    const bookmarkStructure = parseRaindropBackup(htmlContent);
-
-    sendStatusUpdate(
-      'Deleting existing Raindrop folder...',
-      'info',
-      'deleting',
-    );
-
-    // Delete existing Raindrop folder
-    await deleteExistingRaindropFolder();
-
-    sendStatusUpdate('Creating new Raindrop folder...', 'info', 'creating');
-
-    // Create new Raindrop folder in bookmarks bar
-    const bookmarksBar = await chrome.bookmarks.getTree();
-    let parentId = '1'; // Default to bookmarks bar
-
-    if (bookmarksBar && bookmarksBar[0] && bookmarksBar[0].children) {
-      const bookmarksBarNode = bookmarksBar[0].children.find(
-        (node) => node.id === '1',
-      );
-      if (bookmarksBarNode) {
-        parentId = bookmarksBarNode.id;
-      }
-    }
-
-    const raindropFolder = await chrome.bookmarks.create({
-      parentId: parentId,
-      title: 'Raindrop',
-    });
-
-    sendStatusUpdate('Importing bookmarks...', 'info', 'importing');
-
-    // Import all bookmarks into the new folder
-    await createBookmarksFromStructure(raindropFolder.id, bookmarkStructure);
-
-    // Save the bookmark import timestamp
-    await chrome.storage.sync.set({
-      lastImportTime: Date.now(),
-    });
-
-    console.log('Successfully synced Raindrop bookmarks to browser');
-    return true;
-  } catch (error) {
-    console.error('Error syncing Raindrop bookmarks:', error);
-    sendStatusUpdate(`Failed to sync bookmarks: ${error.message}`, 'error');
-    showNotification(
-      'Raindrop Sync Failed',
-      `Failed to import bookmarks to browser: ${error.message}`,
-      'sync-failed',
-    );
-    return false;
   }
 }
 
@@ -230,30 +198,135 @@ async function startBackupProcess(token) {
       return { success: true, message: 'No sync needed - already up to date' };
     }
 
-    // Step 3: New changes found, export all raindrops
-    const changeAge = Math.round(
-      (Date.now() - (syncCheck.latestChangeTimestamp || Date.now())) /
-        (1000 * 60),
-    );
+    // Step 3: Sync needed, prepare collection structure
+    let statusMessage = '';
+    if (syncCheck.reason === 'missing_local_folder') {
+      statusMessage =
+        'Local bookmark folder missing. Restoring your Raindrop bookmarks...';
+    } else {
+      const changeAge = Math.round(
+        (Date.now() - (syncCheck.latestChangeTimestamp || Date.now())) /
+          (1000 * 60),
+      );
+      statusMessage = `New changes found! Latest change was ${changeAge} minutes ago. Setting up collection structure...`;
+    }
+
+    sendStatusUpdate(statusMessage, 'info', 'preparing');
+
+    // Step 3a: Delete existing bookmark folders
     sendStatusUpdate(
-      `New changes found! Latest change was ${changeAge} minutes ago. Exporting...`,
+      'Deleting existing bookmark folders...',
       'info',
-      'exporting',
+      'deleting_folders',
     );
+    await deleteExistingRaindropFolder(); // Delete old "Raindrop" folder
+    await deleteExistingRaindropSyncFolder(); // Delete existing "RaindropSync" folder
 
-    const htmlContent = await exportAllRaindrops(token);
-
-    // Step 4: Parse and import bookmarks
+    // Step 3b: Fetch user data with groups and collection structure from Raindrop API
     sendStatusUpdate(
-      'Importing raindrops to bookmarks...',
+      'Fetching user data and collection structure...',
       'info',
-      'importing',
+      'fetching_collections',
+    );
+    const [userData, rootCollections, childCollections] = await Promise.all([
+      getUserData(token),
+      getRootCollections(token),
+      getChildCollections(token),
+    ]);
+
+    // Step 3c: Build collection tree organized by groups
+    const collectionTree = buildCollectionTreeWithGroups(
+      rootCollections,
+      childCollections,
+      userData.groups || [],
     );
 
-    const syncSuccess = await syncRaindropBookmarks(htmlContent);
-    if (syncSuccess) {
-      // Save the latest change timestamp as the last processed date
+    // Step 3d: Create RaindropSync folder in bookmarks bar
+    sendStatusUpdate(
+      'Creating RaindropSync folder structure...',
+      'info',
+      'creating_sync_folders',
+    );
+    const bookmarksBar = await chrome.bookmarks.getTree();
+    let parentId = '1'; // Default to bookmarks bar
+
+    if (bookmarksBar && bookmarksBar[0] && bookmarksBar[0].children) {
+      const bookmarksBarNode = bookmarksBar[0].children.find(
+        (node) => node.id === '1',
+      );
+      if (bookmarksBarNode) {
+        parentId = bookmarksBarNode.id;
+      }
+    }
+
+    const raindropSyncFolder = await chrome.bookmarks.create({
+      parentId: parentId,
+      title: 'RaindropSync',
+    });
+
+    // Step 3e: Create collection folder structure
+    const collectionToFolderMap = await createCollectionFolderStructure(
+      raindropSyncFolder.id,
+      collectionTree,
+    );
+
+    // Step 3f: Fetch and create bookmarks using paginated API
+    sendStatusUpdate(
+      'Fetching and creating bookmarks...',
+      'info',
+      'fetching_raindrops',
+    );
+
+    let totalBookmarksCreated = 0;
+    let totalBookmarksSkipped = 0;
+    let totalBookmarksErrors = 0;
+
+    // Create callback function to process each page of raindrops
+    const processPageCallback = async (
+      raindrops,
+      pageNumber,
+      totalProcessed,
+    ) => {
+      sendStatusUpdate(
+        `Processing page ${pageNumber + 1}: ${raindrops.length} raindrops (${
+          totalProcessed + raindrops.length
+        } total)...`,
+        'info',
+        'processing_raindrops',
+      );
+
+      // Process this page and create bookmarks
+      const pageResult = await processRaindropsPage(
+        raindrops,
+        collectionToFolderMap,
+        undefined,
+      );
+
+      // Update totals
+      totalBookmarksCreated += pageResult.successCount;
+      totalBookmarksSkipped += pageResult.skipCount;
+      totalBookmarksErrors += pageResult.errorCount;
+
+      return pageResult;
+    };
+
+    // Fetch all raindrops page by page and create bookmarks
+    const fetchResult = await fetchRaindropsPaginated(
+      token,
+      processPageCallback,
+      {}, // Use default options
+    );
+
+    sendStatusUpdate(
+      `Bookmark creation completed: ${totalBookmarksCreated} created, ${totalBookmarksSkipped} skipped, ${totalBookmarksErrors} errors`,
+      totalBookmarksErrors > 0 ? 'warning' : 'success',
+      'completed_bookmarks',
+    );
+
+    if (fetchResult.success && totalBookmarksCreated > 0) {
+      // Save both the import time and the latest change timestamp
       await chrome.storage.sync.set({
+        lastImportTime: Date.now(),
         lastProcessedChangeDate: syncCheck.latestChangeTimestamp,
       });
 
@@ -274,19 +347,24 @@ async function startBackupProcess(token) {
 
       cleanupBackupProcess();
       sendStatusUpdate(
-        'Raindrops exported and imported successfully!',
+        `Sync completed successfully! Created ${totalBookmarksCreated} bookmarks from ${fetchResult.totalPages} pages.`,
         'success',
         'completed',
       );
       showNotification(
         'Raindrop Sync Complete',
-        'Your Raindrop.io bookmarks have been imported to browser bookmarks successfully.',
+        `Successfully synced ${totalBookmarksCreated} raindrops to your browser bookmarks.`,
         'sync-complete',
       );
       return { success: true, message: 'Sync completed successfully' };
     } else {
       cleanupBackupProcess();
-      return { success: false, message: 'Failed to import bookmarks' };
+      const errorMessage =
+        totalBookmarksCreated === 0
+          ? 'No bookmarks were created - check your Raindrop collections'
+          : `Partial sync: ${totalBookmarksCreated} bookmarks created with ${totalBookmarksErrors} errors`;
+      sendStatusUpdate(errorMessage, 'error', 'failed');
+      return { success: false, message: errorMessage };
     }
   } catch (error) {
     console.error('Sync process error:', error);
@@ -553,64 +631,7 @@ chrome.action.onClicked.addListener(async () => {
     case 'open_options':
       chrome.runtime.openOptionsPage();
       break;
-    case 'none':
-      break;
     default:
-      try {
-        await setBadge('⏳');
-
-        const tabs = await chrome.tabs.query({
-          highlighted: true,
-          currentWindow: true,
-        });
-        const raindrops = tabs
-          .filter(
-            (tab) =>
-              tab.url &&
-              (tab.url.startsWith('http:') || tab.url.startsWith('https:')),
-          )
-          .map((tab) => ({
-            link: tab.url,
-            title: tab.title,
-            pleaseParse: {},
-          }));
-
-        await addRaindrops(raindropToken, raindrops);
-
-        const searchResults = await chrome.bookmarks.search({
-          title: 'Raindrop',
-        });
-        let parentId = '1';
-        if (searchResults.length > 0) {
-          const raindropFolder = searchResults.find(
-            (bookmark) => !bookmark.url,
-          );
-          if (raindropFolder) {
-            parentId = raindropFolder.id;
-          }
-        } else {
-          const newFolder = await chrome.bookmarks.create({
-            parentId: '1',
-            title: 'Raindrop',
-          });
-          parentId = newFolder.id;
-        }
-
-        for (const tab of tabs) {
-          await chrome.bookmarks.create({
-            parentId,
-            title: tab.title,
-            url: tab.url,
-          });
-        }
-
-        await setBadge('✅');
-      } catch (error) {
-        console.error('Failed to add bookmark:', error);
-        await setBadge('😵‍💫');
-      } finally {
-        setTimeout(() => clearBadge(), 3000);
-      }
       break;
   }
 });

--- a/src/background.js
+++ b/src/background.js
@@ -189,6 +189,7 @@ async function syncRaindropBookmarks(htmlContent) {
     showNotification(
       'Raindrop Sync Failed',
       `Failed to import bookmarks to browser: ${error.message}`,
+      'sync-failed',
     );
     return false;
   }
@@ -231,7 +232,8 @@ async function startBackupProcess(token) {
 
     // Step 3: New changes found, export all raindrops
     const changeAge = Math.round(
-      (Date.now() - syncCheck.latestChangeTimestamp) / (1000 * 60),
+      (Date.now() - (syncCheck.latestChangeTimestamp || Date.now())) /
+        (1000 * 60),
     );
     sendStatusUpdate(
       `New changes found! Latest change was ${changeAge} minutes ago. Exporting...`,
@@ -293,6 +295,7 @@ async function startBackupProcess(token) {
     showNotification(
       'Raindrop Sync Failed',
       `Sync process failed: ${error.message}`,
+      'backup-failed',
     );
     return { success: false, message: error.message };
   }
@@ -579,7 +582,9 @@ chrome.action.onClicked.addListener(async () => {
         });
         let parentId = '1';
         if (searchResults.length > 0) {
-          const raindropFolder = searchResults.find((bookmark) => !bookmark.url);
+          const raindropFolder = searchResults.find(
+            (bookmark) => !bookmark.url,
+          );
           if (raindropFolder) {
             parentId = raindropFolder.id;
           }

--- a/src/components/bookmarks.js
+++ b/src/components/bookmarks.js
@@ -24,6 +24,91 @@ export async function deleteExistingRaindropFolder() {
 }
 
 /**
+ * Deletes the existing "RaindropSync" folder from browser bookmarks.
+ * This function searches for the folder by title and deletes it.
+ *
+ * @async
+ * @returns {Promise<void>}
+ */
+export async function deleteExistingRaindropSyncFolder() {
+  try {
+    // Search for existing RaindropSync folder
+    const searchResults = await chrome.bookmarks.search({
+      title: 'RaindropSync',
+    });
+
+    for (const bookmark of searchResults) {
+      // Check if this is a folder (no URL means it's a folder)
+      if (!bookmark.url) {
+        console.log(`Deleting existing RaindropSync folder: ${bookmark.id}`);
+        await chrome.bookmarks.removeTree(bookmark.id);
+      }
+    }
+  } catch (error) {
+    console.error('Error deleting existing RaindropSync folder:', error);
+    throw error;
+  }
+}
+
+/**
+ * Creates bookmark folder structure from collection tree.
+ * This function creates a hierarchical folder structure based on Raindrop collections.
+ *
+ * @async
+ * @param {string} parentId - The ID of the parent folder.
+ * @param {Array} collectionTree - The hierarchical collection tree structure.
+ * @returns {Promise<Object>} Map of collection IDs to bookmark folder IDs.
+ */
+export async function createCollectionFolderStructure(
+  parentId,
+  collectionTree,
+) {
+  const collectionToFolderMap = new Map();
+
+  async function createFolderRecursive(parentFolderId, collections) {
+    // Collections are already sorted by the buildCollectionTree function
+    for (const collection of collections) {
+      try {
+        // Create folder for this collection
+        const folder = await chrome.bookmarks.create({
+          parentId: parentFolderId,
+          title: collection.title,
+        });
+
+        console.log(`Created collection folder: ${collection.title}`);
+
+        // Map collection ID to folder ID for later use
+        // Special handling for the Unsorted folder
+        if (collection.id === 'unsorted') {
+          collectionToFolderMap.set('unsorted', folder.id);
+          // Also map ID 0 to unsorted folder (Raindrop uses collection ID 0 for unsorted)
+          collectionToFolderMap.set(0, folder.id);
+        } else {
+          collectionToFolderMap.set(collection.id, folder.id);
+        }
+
+        // Recursively create children folders
+        if (collection.children && collection.children.length > 0) {
+          await createFolderRecursive(folder.id, collection.children);
+        }
+      } catch (error) {
+        console.error(
+          `Error creating collection folder: ${collection.title}`,
+          error,
+        );
+        // Continue with other collections even if one fails
+      }
+    }
+  }
+
+  await createFolderRecursive(parentId, collectionTree);
+  console.log(
+    `Created ${collectionToFolderMap.size} collection folders with proper sorting`,
+  );
+  return collectionToFolderMap;
+}
+
+/**
  * Creates bookmarks from a parsed structure.
  * This function creates folders and bookmarks from the given structure.
  *

--- a/src/components/raindrop.js
+++ b/src/components/raindrop.js
@@ -65,45 +65,243 @@ export async function getLatestChange(token) {
 }
 
 /**
- * Exports all raindrops as HTML directly.
- * This function fetches the HTML content of all raindrops from the Raindrop API.
+ * Fetches raindrops page by page using the Multiple raindrops API.
+ * This function fetches raindrops in paginated manner and processes each page immediately.
  *
  * @async
  * @param {string} token - The API token for the Raindrop API.
- * @returns {Promise<string>} The HTML content of all raindrops.
+ * @param {Function} onPageReceived - Callback function called for each page of raindrops.
+ * @param {Object} [options] - Fetch options.
+ * @param {number} [options.collectionId] - Collection ID (0 for all, -1 for unsorted, etc.)
+ * @param {number} [options.perPage] - Number of raindrops per page (max 50)
+ * @param {boolean} [options.nested] - Include raindrops from nested collections
+ * @param {string} [options.sort] - Sort order (-created, created, title, etc.)
+ * @returns {Promise<Object>} Summary of the fetch process.
  */
-export async function exportAllRaindrops(token) {
+export async function fetchRaindropsPaginated(token, onPageReceived, options) {
   try {
-    console.log('Exporting all raindrops as HTML...');
+    const defaultOptions = {
+      collectionId: 0, // 0 = all collections
+      perPage: 50,
+      nested: true,
+      sort: '-created',
+    };
+    const finalOptions = { ...defaultOptions, ...(options || {}) };
+    const { collectionId, perPage, nested, sort } = finalOptions;
 
-    const response = await fetch(
-      'https://api.raindrop.io/rest/v1/raindrops/0/export.html',
-      {
+    console.log(
+      `Fetching raindrops paginated from collection ${collectionId}...`,
+    );
+
+    let currentPage = 0;
+    let totalFetched = 0;
+    let hasMorePages = true;
+
+    while (hasMorePages) {
+      console.log(
+        `Fetching page ${currentPage} (${perPage} items per page)...`,
+      );
+
+      const url = new URL(
+        `https://api.raindrop.io/rest/v1/raindrops/${collectionId}`,
+      );
+      url.searchParams.set('page', currentPage.toString());
+      url.searchParams.set('perpage', perPage.toString());
+      url.searchParams.set('nested', nested.toString());
+      url.searchParams.set('sort', sort);
+
+      const response = await fetch(url.toString(), {
         method: 'GET',
         headers: {
           Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
         },
-      },
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Failed to fetch raindrops page ${currentPage}: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      const data = await response.json();
+
+      if (!data.result || !data.items) {
+        throw new Error(
+          data.errorMessage || `Failed to fetch raindrops page ${currentPage}`,
+        );
+      }
+
+      const raindrops = data.items;
+      console.log(
+        `Received ${raindrops.length} raindrops on page ${currentPage}`,
+      );
+
+      // Process this page of raindrops
+      if (raindrops.length > 0) {
+        await onPageReceived(raindrops, currentPage, totalFetched);
+        totalFetched += raindrops.length;
+      }
+
+      // Check if there are more pages
+      hasMorePages = raindrops.length === perPage;
+      currentPage++;
+
+      // Safety check to prevent infinite loops
+      if (currentPage > 1000) {
+        console.warn('Reached maximum page limit (1000), stopping fetch');
+        break;
+      }
+    }
+
+    console.log(
+      `Finished fetching raindrops. Total: ${totalFetched} raindrops from ${currentPage} pages`,
     );
 
-    if (response.ok) {
-      const htmlContent = await response.text();
-
-      // Print HTML content in console
-      console.log('=== RAINDROP EXPORT HTML CONTENT ===');
-      console.log(htmlContent);
-      console.log('=== END OF EXPORT CONTENT ===');
-
-      return htmlContent;
-    } else {
-      throw new Error(
-        `Failed to export raindrops: ${response.status} ${response.statusText}`,
-      );
-    }
+    return {
+      totalFetched,
+      totalPages: currentPage,
+      success: true,
+    };
   } catch (error) {
-    console.error('Error exporting raindrops:', error);
+    console.error('Error fetching raindrops paginated:', error);
     throw error;
   }
+}
+
+/**
+ * Creates a browser bookmark from a raindrop object.
+ * This function creates a bookmark in the appropriate folder based on the raindrop's collection ID.
+ * For collection handling:
+ * - Collection found: Creates bookmark in the corresponding folder
+ * - Collection -1: Creates bookmark in unsorted folder
+ * - Other missing collections: Ignores the bookmark (returns null)
+ *
+ * @async
+ * @param {Object} raindrop - The raindrop object from the API.
+ * @param {Map} collectionToFolderMap - Map of collection IDs to bookmark folder IDs.
+ * @returns {Promise<Object|null>} The created bookmark object, or null if bookmark is ignored.
+ */
+export async function createBookmarkFromRaindrop(
+  raindrop,
+  collectionToFolderMap,
+) {
+  try {
+    // Get the collection ID from the raindrop
+    const collectionId = raindrop.collection?.$id || 0; // Default to 0 (unsorted) if no collection
+
+    // Find the corresponding folder ID
+    let folderId = collectionToFolderMap.get(collectionId);
+
+    // Handle not found collections based on specific rules
+    if (!folderId) {
+      if (collectionId === -1) {
+        // -1: put to unsorted folder
+        folderId =
+          collectionToFolderMap.get('unsorted') || collectionToFolderMap.get(0);
+        if (!folderId) {
+          throw new Error(`No unsorted folder available for collection -1`);
+        }
+        console.log(`Collection -1 (unsorted) mapped to unsorted folder`);
+      } else {
+        // others: ignore that bookmark
+        console.warn(
+          `Collection ${collectionId} not found in folder map, ignoring bookmark: ${raindrop.title}`,
+        );
+        return null;
+      }
+    }
+
+    // Prepare bookmark title (truncate if too long)
+    let title = raindrop.title || 'Untitled';
+    if (title.length > 1000) {
+      title = title.substring(0, 997) + '...';
+    }
+
+    // Ensure we have a valid URL
+    const url = raindrop.link;
+    if (!url || (!url.startsWith('http://') && !url.startsWith('https://'))) {
+      console.warn(
+        `Skipping raindrop with invalid URL: ${url} (title: ${title})`,
+      );
+      return null;
+    }
+
+    // Create the bookmark
+    const bookmark = await chrome.bookmarks.create({
+      parentId: folderId,
+      title: title,
+      url: url,
+    });
+
+    console.log(`Created bookmark: ${title} in collection ${collectionId}`);
+    return bookmark;
+  } catch (error) {
+    console.error('Error creating bookmark from raindrop:', error, raindrop);
+    return null;
+  }
+}
+
+/**
+ * Processes a page of raindrops and creates bookmarks for each one.
+ * This function is used as a callback for the paginated raindrop fetching.
+ *
+ * @async
+ * @param {Array} raindrops - Array of raindrop objects from the API.
+ * @param {Map} collectionToFolderMap - Map of collection IDs to bookmark folder IDs.
+ * @param {Function|undefined} onProgress - Optional progress callback function.
+ * @returns {Promise<Object>} Processing results.
+ */
+export async function processRaindropsPage(
+  raindrops,
+  collectionToFolderMap,
+  onProgress,
+) {
+  let successCount = 0;
+  let skipCount = 0;
+  let errorCount = 0;
+
+  for (let i = 0; i < raindrops.length; i++) {
+    const raindrop = raindrops[i];
+
+    try {
+      const bookmark = await createBookmarkFromRaindrop(
+        raindrop,
+        collectionToFolderMap,
+      );
+
+      if (bookmark) {
+        successCount++;
+      } else {
+        skipCount++;
+      }
+
+      // Call progress callback if provided
+      if (onProgress && typeof onProgress === 'function') {
+        onProgress(
+          i + 1,
+          raindrops.length,
+          successCount,
+          skipCount,
+          errorCount,
+        );
+      }
+    } catch (error) {
+      console.error(`Error processing raindrop: ${raindrop.title}`, error);
+      errorCount++;
+    }
+  }
+
+  console.log(
+    `Page processing completed: ${successCount} created, ${skipCount} skipped, ${errorCount} errors`,
+  );
+
+  return {
+    successCount,
+    skipCount,
+    errorCount,
+    totalProcessed: raindrops.length,
+  };
 }
 
 /**
@@ -308,4 +506,334 @@ export async function addRaindrops(token, raindrops) {
     console.error('Error adding raindrops:', error);
     throw error;
   }
+}
+
+/**
+ * Fetches user data including groups information from the Raindrop API.
+ * This function gets the authenticated user's data, which includes groups that organize collections.
+ *
+ * @async
+ * @param {string} token - The API token for the Raindrop API.
+ * @returns {Promise<Object>} User data object containing groups information.
+ */
+export async function getUserData(token) {
+  try {
+    console.log('Fetching user data with groups...');
+
+    const response = await fetch('https://api.raindrop.io/rest/v1/user', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.result && data.user) {
+        console.log(
+          `Found user data with ${data.user.groups?.length || 0} groups`,
+        );
+        return data.user;
+      } else {
+        throw new Error(data.errorMessage || 'Failed to fetch user data');
+      }
+    } else {
+      throw new Error(
+        `Failed to fetch user data: ${response.status} ${response.statusText}`,
+      );
+    }
+  } catch (error) {
+    console.error('Error fetching user data:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetches all root collections from the Raindrop API.
+ * This function gets all collections that don't have a parent (root level).
+ *
+ * @async
+ * @param {string} token - The API token for the Raindrop API.
+ * @returns {Promise<Array>} Array of root collections.
+ */
+export async function getRootCollections(token) {
+  try {
+    console.log('Fetching root collections...');
+
+    const response = await fetch(
+      'https://api.raindrop.io/rest/v1/collections',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.result && data.items) {
+        console.log(`Found ${data.items.length} root collections`);
+        return data.items;
+      } else {
+        throw new Error(
+          data.errorMessage || 'Failed to fetch root collections',
+        );
+      }
+    } else {
+      throw new Error(
+        `Failed to fetch root collections: ${response.status} ${response.statusText}`,
+      );
+    }
+  } catch (error) {
+    console.error('Error fetching root collections:', error);
+    throw error;
+  }
+}
+
+/**
+ * Fetches all child collections from the Raindrop API.
+ * This function gets all collections that have a parent (nested collections).
+ *
+ * @async
+ * @param {string} token - The API token for the Raindrop API.
+ * @returns {Promise<Array>} Array of child collections.
+ */
+export async function getChildCollections(token) {
+  try {
+    console.log('Fetching child collections...');
+
+    const response = await fetch(
+      'https://api.raindrop.io/rest/v1/collections/childrens',
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+
+    if (response.ok) {
+      const data = await response.json();
+      if (data.result && data.items) {
+        console.log(`Found ${data.items.length} child collections`);
+        return data.items;
+      } else {
+        throw new Error(
+          data.errorMessage || 'Failed to fetch child collections',
+        );
+      }
+    } else {
+      throw new Error(
+        `Failed to fetch child collections: ${response.status} ${response.statusText}`,
+      );
+    }
+  } catch (error) {
+    console.error('Error fetching child collections:', error);
+    throw error;
+  }
+}
+
+/**
+ * Builds a hierarchical collection tree structure from root and child collections.
+ * This function organizes collections into a tree structure based on parent-child relationships.
+ *
+ * @param {Array} rootCollections - Array of root collections.
+ * @param {Array} childCollections - Array of child collections.
+ * @returns {Array} Hierarchical tree structure of collections.
+ */
+export function buildCollectionTree(rootCollections, childCollections) {
+  console.log('Building collection tree structure...');
+
+  // Create a map for quick lookup of children by parent ID
+  const childrenByParent = new Map();
+
+  childCollections.forEach((collection) => {
+    const parentId = collection.parent?.$id;
+    if (parentId) {
+      if (!childrenByParent.has(parentId)) {
+        childrenByParent.set(parentId, []);
+      }
+      childrenByParent.get(parentId).push(collection);
+    }
+  });
+
+  // Sort children by their sort value (descending, as per Raindrop API)
+  childrenByParent.forEach((children) => {
+    children.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+  });
+
+  // Recursive function to attach children to their parents
+  function attachChildren(collection) {
+    const children = childrenByParent.get(collection._id) || [];
+    return {
+      id: collection._id,
+      title: collection.title,
+      sort: collection.sort || 0,
+      children: children.map((child) => attachChildren(child)),
+    };
+  }
+
+  // Sort root collections by their sort value (descending)
+  const sortedRootCollections = [...rootCollections].sort(
+    (a, b) => (a.sort || 0) - (b.sort || 0),
+  );
+
+  // Build the tree starting from sorted root collections
+  const tree = sortedRootCollections.map((root) => attachChildren(root));
+
+  // Add "Unsorted" folder at the beginning
+  const unsortedFolder = {
+    id: 'unsorted',
+    title: 'Unsorted',
+    sort: Number.MAX_SAFE_INTEGER, // Ensure it sorts first
+    children: [],
+  };
+
+  tree.unshift(unsortedFolder);
+
+  console.log(
+    `Built collection tree with ${tree.length} collections (including Unsorted)`,
+  );
+  return tree;
+}
+
+/**
+ * Builds a hierarchical collection tree structure organized by groups.
+ * This function organizes collections into groups and maintains hierarchical structure within each group.
+ *
+ * @param {Array} rootCollections - Array of root collections.
+ * @param {Array} childCollections - Array of child collections.
+ * @param {Array} groups - Array of groups that organize collections.
+ * @returns {Array} Hierarchical tree structure organized by groups.
+ */
+export function buildCollectionTreeWithGroups(
+  rootCollections,
+  childCollections,
+  groups,
+) {
+  console.log('Building collection tree structure with groups...');
+
+  // First build the basic collection tree structure
+  const childrenByParent = new Map();
+  childCollections.forEach((collection) => {
+    const parentId = collection.parent?.$id;
+    if (parentId) {
+      if (!childrenByParent.has(parentId)) {
+        childrenByParent.set(parentId, []);
+      }
+      childrenByParent.get(parentId).push(collection);
+    }
+  });
+
+  // Sort children by their sort value
+  childrenByParent.forEach((children) => {
+    children.sort((a, b) => (a.sort || 0) - (b.sort || 0));
+  });
+
+  // Create maps for quick lookup
+  const allCollections = new Map();
+  [...rootCollections, ...childCollections].forEach((collection) => {
+    allCollections.set(collection._id, collection);
+  });
+
+  // Recursive function to attach children to their parents
+  function attachChildren(collection) {
+    const children = childrenByParent.get(collection._id) || [];
+    return {
+      id: collection._id,
+      title: collection.title,
+      sort: collection.sort || 0,
+      children: children.map((child) => attachChildren(child)),
+    };
+  }
+
+  const result = [];
+
+  // Add "Unsorted" folder first
+  const unsortedFolder = {
+    id: 'unsorted',
+    title: 'Unsorted',
+    sort: -1, // Ensure it sorts first
+    children: /** @type {Array} */ ([]),
+    isGroup: false,
+  };
+  result.push(unsortedFolder);
+
+  if (groups && groups.length > 0) {
+    // Sort groups by their sort value
+    const sortedGroups = [...groups].sort(
+      (a, b) => (a.sort || 0) - (b.sort || 0),
+    );
+
+    // Process each group
+    sortedGroups.forEach((group) => {
+      const groupFolder = {
+        id: `group_${group.title}`,
+        title: group.title,
+        sort: group.sort || 0,
+        children: /** @type {Array} */ ([]),
+        isGroup: true,
+        hidden: group.hidden || false,
+      };
+
+      // Add collections to this group in the specified order
+      if (group.collections && group.collections.length > 0) {
+        group.collections.forEach((collectionId) => {
+          const collection = allCollections.get(collectionId);
+          if (collection) {
+            // Only add root collections here; children will be attached recursively
+            if (!collection.parent || !collection.parent.$id) {
+              groupFolder.children.push(attachChildren(collection));
+            }
+          }
+        });
+      }
+
+      result.push(groupFolder);
+    });
+
+    // Handle collections not in any group (add them to a default "Other" group)
+    const collectionsInGroups = new Set();
+    groups.forEach((group) => {
+      if (group.collections) {
+        group.collections.forEach((id) => collectionsInGroups.add(id));
+      }
+    });
+
+    const ungroupedCollections = rootCollections.filter(
+      (collection) => !collectionsInGroups.has(collection._id),
+    );
+
+    if (ungroupedCollections.length > 0) {
+      const otherFolder = {
+        id: 'group_other',
+        title: 'Other',
+        sort: Number.MAX_SAFE_INTEGER,
+        children: /** @type {Array} */ (
+          ungroupedCollections.map((collection) => attachChildren(collection))
+        ),
+        isGroup: true,
+        hidden: false,
+      };
+      result.push(otherFolder);
+    }
+  } else {
+    // No groups defined, fall back to the original structure
+    console.log('No groups found, falling back to original structure');
+    const sortedRootCollections = [...rootCollections].sort(
+      (a, b) => (a.sort || 0) - (b.sort || 0),
+    );
+
+    const tree = sortedRootCollections.map((root) => attachChildren(root));
+    result.push(...tree);
+  }
+
+  console.log(
+    `Built collection tree with ${result.length} top-level items (including groups and Unsorted)`,
+  );
+  return result;
 }

--- a/src/components/raindrop.js
+++ b/src/components/raindrop.js
@@ -25,7 +25,9 @@ export async function getLatestChange(token) {
     const promises = urls.map((url) =>
       fetch(url, fetchOptions).then((res) => {
         if (!res.ok) {
-          throw new Error(`API request failed: ${res.status} ${res.statusText}`);
+          throw new Error(
+            `API request failed: ${res.status} ${res.statusText}`,
+          );
         }
         return res.json();
       }),
@@ -122,9 +124,7 @@ export function parseRaindropBackup(htmlContent) {
       parsedStructure[0].type === 'folder' &&
       parsedStructure[0].title === 'Export'
     ) {
-      console.log(
-        'Detected "Export" folder, using its content as the root.',
-      );
+      console.log('Detected "Export" folder, using its content as the root.');
       return parsedStructure[0].children;
     }
 
@@ -272,13 +272,12 @@ function getCurrentLevel(line) {
 }
 
 /**
- * Adds a new raindrop to the user's collection.
+ * Adds new raindrops to the user's collection.
  *
  * @async
  * @param {string} token - The API token for the Raindrop API.
- * @param {string} url - The URL of the page to add.
- * @param {string} title - The title of the page.
- * @returns {Promise<Object>} The newly created raindrop.
+ * @param {Array<Object>} raindrops - An array of raindrop objects to add.
+ * @returns {Promise<Array<Object>>} The newly created raindrops.
  */
 export async function addRaindrops(token, raindrops) {
   try {


### PR DESCRIPTION
This update enhances Raindrop-to-browser bookmark syncing by preserving the original structure of collections and groups. Key changes:

- 📁 Constructs a hierarchical bookmark folder tree based on Raindrop collections and group layout  
- 🧹 Deletes existing `RaindropSync` folders before rebuild to ensure a **full replacement** of prior bookmarks  
- 🚀 Fetches Raindrops via paginated API and places them accurately into their mapped folders  
- 🧠 Extracts and organizes Raindrop user, collection, and raindrop metadata for smart syncing  
- ✅ Displays clearer sync status updates and improved error handling throughout

> 🔄 **Note:** This is still a **full replacement** of the local `RaindropSync` bookmark folder on each sync.  
> Future work will explore **incremental sync**, updating only changed or new bookmarks without full deletion.